### PR TITLE
Add support for clouds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,6 @@ jobs:
 
       - name: Run linters
         run: helm lint charts/openstack-ck8s-cluster
+
+      - name: Package the chart
+        run: helm package -u charts/openstack-ck8s-cluster

--- a/charts/openstack-ck8s-cluster/Chart.yaml
+++ b/charts/openstack-ck8s-cluster/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.1.0
 appVersion: "1.9.6"
 
 dependencies:
-  - name: autoscaler
+  - name: cluster-autoscaler
     # https://kubernetes.github.io/autoscaler/index.yaml
     # Check helm chart version based on application version
     version: "9.37.0"

--- a/charts/openstack-ck8s-cluster/templates/addons/secret-type-crs-cloud-config.yaml
+++ b/charts/openstack-ck8s-cluster/templates/addons/secret-type-crs-cloud-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cloudCredentialsSecretName -}}
 {{- $secretName := include "openstack-ck8s-cluster.cloudCredentialsSecretName" . -}}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName  -}}
 {{- if $existingSecret }}
@@ -22,4 +23,37 @@ stringData:
       {{- range $key, $value := $existingSecret.data }}
       {{ $key }}: {{ $value }}
       {{- end }}
+{{- else }}
+{{- fail "Secret specified in cloudCredentialsSecretName not found" }}
+{{- end }}
+{{- else if .Values.clouds }}
+{{- $cloud := index .Values.clouds .Values.cloudName }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openstack-ck8s-cluster.cloudCredentialsSecretName" . }}-for-crs
+  labels: {{ include "openstack-ck8s-cluster.componentLabels" (list . "cloud-credentials") | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+type: addons.cluster.x-k8s.io/resource-set
+stringData:
+  my-target-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cloud-config-credentials
+      namespace: openstack-system
+    type: Opaque
+    stringData:
+      clouds.yaml: |
+        clouds:
+          {{ printf "%s:" .Values.cloudName }}
+            {{ index .Values.clouds .Values.cloudName | toYaml | indent 12 | trim }}
+      {{- with .Values.cloudCACert }}
+      cacert: |
+        {{ . | indent 4 | trim }}
+      {{- end }}
+{{- else }}
+{{- fail "clouds must be specified if cloudCredentialsSecretName is not given" }}
 {{- end }}


### PR DESCRIPTION
Currently the ClusterResourceSet secret supports only if user provides cloud credentials as secret. Extend the functionality to support clouds.yaml from user.

Update dependency chart name for autoscaler to cluster-autoscaler

Note: Autoscaler is not working and will be fixed in subsequent PR.