### PR TITLE
Add kubernetes dashboard addon

### DIFF
--- a/charts/openstack-ck8s-cluster/templates/addons/k8s-dashboard.yaml
+++ b/charts/openstack-ck8s-cluster/templates/addons/k8s-dashboard.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: {{ include "openstack-ck8s-cluster.componentName" (list . "kubernetes-dashboard") }}
+  labels: {{ include "openstack-ck8s-cluster.componentLabels" (list . "kubernetes-dashboard") | nindent 4 }}
+spec:
+  clusterSelector:
+    matchLabels:
+      kubernetesDashboardChart: enabled
+  namespace: kubernetes-dashboard
+  repoURL: https://kubernetes.github.io/dashboard
+  chartName: kubernetes-dashboard
+  version: 7.13.0
+  options:
+    waitForJobs: true
+    wait: true
+    timeout: 5m
+    install:
+      createNamespace: true

--- a/charts/openstack-ck8s-cluster/templates/cluster.yaml
+++ b/charts/openstack-ck8s-cluster/templates/cluster.yaml
@@ -7,6 +7,9 @@ metadata:
     {{ include "openstack-ck8s-cluster.labels" . | nindent 4 }}
     ccmOpenStackChart: enabled
     csiCinderChart: enabled
+    {{- if .Values.addons.kubernetesDashboard.enabled }}
+    kubernetesDashboardChart: enabled
+    {{- end }}
 spec:
   clusterNetwork: {{ .Values.clusterNetwork | toYaml | nindent 4 }}
   controlPlaneRef:

--- a/charts/openstack-ck8s-cluster/values.yaml
+++ b/charts/openstack-ck8s-cluster/values.yaml
@@ -166,6 +166,12 @@ addons:
         # reclaimPolicy: Retain
         # volumeType: Volume type to be configured for storage class (string)
         # volumeType: __DEFAULT__
+  # kubernetes dashboard addon
+  # https://kubernetes.github.io/dashboard/index.yaml
+  kubernetesDashboard:
+    # enabled: Enable k8s dashboard or not (boolean)
+    enabled: False
+
 
 ###########################################
 # Dependency charts values.yaml overrides #


### PR DESCRIPTION
Add kubernetes dashboard as an addon using
HelmChartProxy. Control the deployment of
chart in the cluster based on values

```
addons:
  kubernetesDashboard:
    enabled: False
```