### PR TITLE
Add support for k8s-keystone-auth addon

### DIFF
--- a/charts/openstack-ck8s-cluster/templates/addons/k8s-keystone-auth.yaml
+++ b/charts/openstack-ck8s-cluster/templates/addons/k8s-keystone-auth.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.addons.openstack.k8sKeystoneAuth.enabled }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: {{ include "openstack-ck8s-cluster.componentName" (list . "k8s-keystone-auth") }}
+  labels: {{ include "openstack-ck8s-cluster.componentLabels" (list . "k8s-keystone-auth") | nindent 4 }}
+spec:
+  clusterSelector:
+    matchLabels:
+      k8sKeystoneAuthChart: enabled
+  namespace: kube-system
+  repoURL: https://catalyst-cloud.github.io/capi-plugin-helm-charts
+  chartName: k8s-keystone-auth
+  version: 1.5.1
+  options:
+    waitForJobs: true
+    wait: true
+    timeout: 5m
+    install:
+      createNamespace: true
+  {{- if and .Values.addons.openstack.k8sKeystoneAuth.values .Values.addons.openstack.k8sKeystoneAuth.values.openstackAuthUrl .Values.addons.openstack.k8sKeystoneAuth.values.projectId }}
+  valuesTemplate: |
+    {{- toYaml .Values.addons.openstack.k8sKeystoneAuth.values | nindent 4 }}
+  {{- else }}
+  {{- fail (printf "Required k8sKeystoneAuth openstackAuthUrl and projectId") }}
+  {{- end }}
+{{- end }}

--- a/charts/openstack-ck8s-cluster/templates/cluster.yaml
+++ b/charts/openstack-ck8s-cluster/templates/cluster.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- if .Values.addons.kubernetesDashboard.enabled }}
     kubernetesDashboardChart: enabled
     {{- end }}
+    {{- if .Values.addons.openstack.k8sKeystoneAuth.enabled }}
+    k8sKeystoneAuthChart: enabled
+    {{- end }}
 spec:
   clusterNetwork: {{ .Values.clusterNetwork | toYaml | nindent 4 }}
   controlPlaneRef:

--- a/charts/openstack-ck8s-cluster/templates/control-plane/canonical-k8s-control-plane.yaml
+++ b/charts/openstack-ck8s-cluster/templates/control-plane/canonical-k8s-control-plane.yaml
@@ -23,8 +23,36 @@ spec:
   remediationStrategy: {{ toYaml .Values.ck8sControlPlane.remediationStrategy | nindent 4 }}
   replicas: {{ .Values.controlPlane.machineCount }}
   spec:
+    {{- if .Values.addons.openstack.k8sKeystoneAuth.enabled }}
+    files:
+      - path: /var/snap/k8s/common/args/conf.d/k8s-auth-token-webhook.conf
+        content: |
+          apiVersion: v1
+          kind: Config
+          clusters:
+          - cluster:
+              insecure-skip-tls-verify: true
+              server: https://127.0.0.1:8443/webhook
+            name: webhook
+          users:
+          - name: webhook
+          contexts:
+          - context:
+              cluster: webhook
+              user: webhook
+            name: webhook
+          current-context: webhook
+    postRunCommands:
+      - echo "--authentication-token-webhook-config-file=/var/snap/k8s/common/args/conf.d/k8s-auth-token-webhook.conf" >> /var/snap/k8s/common/args/kube-apiserver
+      - sudo snap restart k8s.kube-apiserver
+    {{- end }}
     controlPlane:
       cloudProvider: external
+      {{- if .Values.addons.openstack.k8sKeystoneAuth.enabled }}
+      extraKubeAPIServerArgs:
+        --authorization-webhook-config-file: /var/snap/k8s/common/args/conf.d/k8s-auth-token-webhook.conf
+        --authorization-mode: Node,RBAC,Webhook
+      {{- end }}
     extraKubeletArgs:
       --provider-id: openstack:///{{ "{{" }} instance_id {{ "}}" }}
   version: v{{ .Values.kubernetesVersion | trimPrefix "v" }}

--- a/charts/openstack-ck8s-cluster/values.yaml
+++ b/charts/openstack-ck8s-cluster/values.yaml
@@ -143,6 +143,7 @@ addons:
           # lb-provider: OpenStack Octavia provider. Expected values are ovn, octavia (string)
           # lb-method: OpenStack Octavia Loadbalancing method. ovn provider only supports SOURCE_IP_PORT (string)
           # create-monitor: Whether to create monitors for OpenStack loadbalancers (boolean)
+
     # https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/cinder-csi-plugin/values.yaml
     # csiCinder: Cinder related configuration values (dictionary)
     csiCinder: {}
@@ -166,6 +167,19 @@ addons:
         # reclaimPolicy: Retain
         # volumeType: Volume type to be configured for storage class (string)
         # volumeType: __DEFAULT__
+
+    # k8s-keystone-auth addon
+    # https://github.com/catalyst-cloud/capi-plugin-helm-charts/blob/main/charts/k8s-keystone-auth
+    k8sKeystoneAuth:
+      # enabled: Enable keystone-k8s-auth or not (boolean)
+      enabled: False
+      # Values required for the helm chart (dictionary)
+      # values:
+        # openstackAuthUrl: Auth URL of Openstack cloud (string)
+        # openstackAuthUrl:
+        # proejctId: Project ID in which the k8s cluster is deployed (string)
+        # projectId:
+
   # kubernetes dashboard addon
   # https://kubernetes.github.io/dashboard/index.yaml
   kubernetesDashboard:


### PR DESCRIPTION
Add HelmChartProxy to deploy k8s-keystone-auth helm chart

Drop the webhook config file using Files option in CK8sControlPlane

Update kube-apiserver flags to add
--authentication-token-webhook-config-file=<>
--authorization-webhook-config-file=<>
--authorization-mode=Node,RBAC,Webhook

Due to [1], it is not possible to add flag
--authentication-token-webhook-config using
extraKubeAPIServerArgs, so use PostCommands to append the flag to kube-apiserver args file and restart the service. Use extraKubeAPIServerArgs to update authorization related flags.

[1] https://github.com/canonical/cluster-api-k8s/issues/177